### PR TITLE
Allow remote hero image domain

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,12 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "hebbkx1anhila5yf.public.blob.vercel-storage.com",
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## Summary
- allow loading hero imagery from the Vercel Blob storage host by configuring the Next.js image settings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f46c575a508321b1d7f5c3fa48850e